### PR TITLE
fix: Rename function to resolve duplicate export error

### DIFF
--- a/components/ChatModal.tsx
+++ b/components/ChatModal.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import type { MediaDetails, ChatMessage, Brand } from '../types.ts';
 import { CloseIcon, SendIcon } from './icons.tsx';
 import { LoadingSpinner } from './LoadingSpinner.tsx';
-import { startChatForMedia, startChatForBrand } from '../services/aiService.ts';
+import { startChatForMedia, startChatForBrandNew } from '../services/aiService.ts';
 import { RateLimitMessage } from './RateLimitMessage.tsx';
 import type { Chat } from '@google/genai';
 import { useSettings } from '../hooks/useSettings.ts';
@@ -38,7 +38,7 @@ export const ChatModal: React.FC<ChatModalProps> = ({ isOpen, onClose, media, br
         let initialMessage: ChatMessage;
 
         if (brand) {
-            session = startChatForBrand(brand, aiClient);
+            session = startChatForBrandNew(brand, aiClient);
             initialMessage = { role: 'model', content: `Hi! I'm ScapeAI. I can answer any questions you have about the "${brand.name}" franchise. What would you like to know?` };
         } else if (media) {
             session = startChatForMedia(media, aiClient);

--- a/services/aiService.ts
+++ b/services/aiService.ts
@@ -302,7 +302,7 @@ export const startChatForMedia = (media: MediaDetails, aiClient: GoogleGenAI): C
  * @param brand The brand to chat about.
  * @returns An initialized `Chat` object from the Gemini SDK.
  */
-export const startChatForBrand = (brand: Brand, aiClient: GoogleGenAI): Chat => {
+export const startChatForBrandNew = (brand: Brand, aiClient: GoogleGenAI): Chat => {
     const chat = aiClient.chats.create({
         model,
         config: {


### PR DESCRIPTION
The Vercel build was failing due to a duplicate export of the `startChatForBrand` function in `services/aiService.ts`. This change renames the function to `startChatForBrandNew` and updates its usage in `components/ChatModal.tsx` to resolve the conflict.